### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/abilian/core/models/__init__.py
+++ b/abilian/core/models/__init__.py
@@ -56,7 +56,7 @@ class BaseMixin(IdMixin, TimestampedMixin, OwnedMixin):
     return json.dumps(self.to_dict())
 
   def _icon(self, size=12):
-    return "/static/icons/%s-%d.png" % (self.__class__.__name__.lower(), size)
+    return "/static/icons/{0!s}-{1:d}.png".format(self.__class__.__name__.lower(), size)
 
   #FIXME: we can do better than that
   @property

--- a/abilian/core/models/owned.py
+++ b/abilian/core/models/owned.py
@@ -36,7 +36,7 @@ class OwnedMixin(object):
 
   @declared_attr
   def creator(cls):
-    pj = "User.id == %s.creator_id" % cls.__name__
+    pj = "User.id == {0!s}.creator_id".format(cls.__name__)
     return relationship(User, primaryjoin=pj, lazy='joined', uselist=False,
                         info=SYSTEM | SEARCHABLE)
 
@@ -50,7 +50,7 @@ class OwnedMixin(object):
 
   @declared_attr
   def owner(cls):
-    pj = "User.id == %s.owner_id" % cls.__name__
+    pj = "User.id == {0!s}.owner_id".format(cls.__name__)
     return relationship(User, primaryjoin=pj, lazy='joined', uselist=False,
                         info=EDITABLE | AUDITABLE | SEARCHABLE)
 

--- a/abilian/core/sqlalchemy.py
+++ b/abilian/core/sqlalchemy.py
@@ -379,7 +379,7 @@ class UUID(sa.types.TypeDecorator):
       if not isinstance(value, uuid.UUID):
         value = uuid.UUID(value)
       # hexstring
-      return "%.32x" % value
+      return "{0:.32x}".format(value)
 
   def process_result_value(self, value, dialect):
     return value if value is None else uuid.UUID(value)
@@ -407,7 +407,7 @@ class Locale(sa.types.TypeDecorator):
 
     if not isinstance(value, babel.Locale):
       if not isinstance(value, string_types):
-        raise ValueError("Unknown locale value: %s" % repr(value))
+        raise ValueError("Unknown locale value: {0!s}".format(repr(value)))
       if not value.strip():
         return None
       value = babel.Locale.parse(value)
@@ -440,7 +440,7 @@ class Timezone(sa.types.TypeDecorator):
 
     if not isinstance(value, pytz.tzfile.DstTzInfo):
       if not isinstance(value, string_types):
-        raise ValueError("Unknown timezone value: %s" % repr(value))
+        raise ValueError("Unknown timezone value: {0!s}".format(repr(value)))
       if not value.strip():
         return None
       value = babel.dates.get_timezone(value)

--- a/abilian/core/util.py
+++ b/abilian/core/util.py
@@ -223,7 +223,7 @@ def slugify(value, separator=u"-"):
   value = value.encode('ascii', 'ignore')
   value = value.decode('ascii')
   value = value.strip().lower()
-  value = re.sub(r'[%s_\s]+' % separator, separator, value)
+  value = re.sub(r'[{0!s}_\s]+'.format(separator), separator, value)
   return value
 
 

--- a/abilian/plugin/loader.py
+++ b/abilian/plugin/loader.py
@@ -32,10 +32,10 @@ class AppLoader(ModuleLoader):
     for mod in self:
 
       if logger:
-        logger.info("Register module: %s" % mod.__name__)
+        logger.info("Register module: {0!s}".format(mod.__name__))
 
       if submodule:
-        mod = self.import_module('%s.%s' % (mod.__name__, submodule))
+        mod = self.import_module('{0!s}.{1!s}'.format(mod.__name__, submodule))
 
       meta = self._meta(mod)
 

--- a/abilian/services/auth/views.py
+++ b/abilian/services/auth/views.py
@@ -327,7 +327,7 @@ def send_mail(subject, recipient, template, **context):
                 recipients=[recipient])
 
   ctx = ('login/email', template)
-  msg.body = render_template_i18n('%s/%s.txt' % ctx, **context)
+  msg.body = render_template_i18n('{0!s}/{1!s}.txt'.format(*ctx), **context)
   #msg.html = render_template('%s/%s.html' % ctx, **context)
 
   mail = current_app.extensions.get('mail')

--- a/abilian/services/conversion.py
+++ b/abilian/services/conversion.py
@@ -145,7 +145,7 @@ class Converter(object):
         pdf = handler.convert(blob)
         self.cache[cache_key] = pdf
         return pdf
-    raise ConversionError("No handler found to convert from %s to PDF" % mime_type)
+    raise ConversionError("No handler found to convert from {0!s} to PDF".format(mime_type))
 
   def to_text(self, digest, blob, mime_type):
     """Converts a file to plain text.
@@ -182,7 +182,7 @@ class Converter(object):
   def has_image(self, digest, mime_type, index, size=500):
     """ Tell if there is a preview image
     """
-    cache_key = "img:%s:%s:%s" % (index, size, digest)
+    cache_key = "img:{0!s}:{1!s}:{2!s}".format(index, size, digest)
     return mime_type.startswith("image/") or cache_key in self.cache
 
   def get_image(self, digest, blob, mime_type, index, size=500):
@@ -193,7 +193,7 @@ class Converter(object):
     if mime_type.startswith("image/"):
       return ""
 
-    cache_key = "img:%s:%s:%s" % (index, size, digest)
+    cache_key = "img:{0!s}:{1!s}:{2!s}".format(index, size, digest)
     return self.cache.get(cache_key)
 
   def to_image(self, digest, blob, mime_type, index, size=500):
@@ -204,7 +204,7 @@ class Converter(object):
     if mime_type.startswith("image/"):
       return ""
 
-    cache_key = "img:%s:%s:%s" % (index, size, digest)
+    cache_key = "img:{0!s}:{1!s}:{2!s}".format(index, size, digest)
     converted = self.cache.get(cache_key)
     if converted:
       return converted
@@ -215,7 +215,7 @@ class Converter(object):
         converted_images = handler.convert(blob, size=size)
         for i in range(0, len(converted_images)):
           converted = converted_images[i]
-          self.cache["img:%s:%s:%s" % (i, size, digest)] = converted
+          self.cache["img:{0!s}:{1!s}:{2!s}".format(i, size, digest)] = converted
         return converted_images[index]
 
     # Use PDF as a pivot format
@@ -225,7 +225,7 @@ class Converter(object):
         converted_images = handler.convert(pdf, size=size)
         for i in range(0, len(converted_images)):
           converted = converted_images[i]
-          self.cache["img:%s:%s:%s" % (i, size, digest)] = converted
+          self.cache["img:{0!s}:{1!s}:{2!s}".format(i, size, digest)] = converted
         return converted_images[index]
 
     raise ConversionError()
@@ -302,12 +302,12 @@ class Handler(object):
     match_target = False
 
     for pat in self.accepts_mime_types:
-      if re.match("^%s$" % pat, source_mime_type):
+      if re.match("^{0!s}$".format(pat), source_mime_type):
         match_source = True
         break
 
     for pat in self.produces_mime_types:
-      if re.match("^%s$" % pat, target_mime_type):
+      if re.match("^{0!s}$".format(pat), target_mime_type):
         match_target = True
         break
 
@@ -426,7 +426,7 @@ class PdfToPpmHandler(Handler):
     with make_temp_file(blob) as in_fn, make_temp_file() as out_fn:
       try:
         subprocess.check_call(['pdftoppm', '-jpeg', in_fn, out_fn])
-        l = glob.glob("%s-*.jpg" % out_fn)
+        l = glob.glob("{0!s}-*.jpg".format(out_fn))
         l.sort()
 
         converted_images = []
@@ -574,8 +574,8 @@ class CloudoooPdfHandler(Handler):
     }
 
   def convert(self, key):
-    in_fn = "data/%s.blob" % key
-    in_mime_type = open("data/%s.mime" % key).read()
+    in_fn = "data/{0!s}.blob".format(key)
+    in_mime_type = open("data/{0!s}.mime".format(key)).read()
     file_extension = mimetypes.guess_extension(in_mime_type).strip(".")
 
     data = encodestring(open(in_fn).read())
@@ -590,7 +590,7 @@ class CloudoooPdfHandler(Handler):
 
     converted = decodestring(data)
     new_key = hashlib.md5(converted).hexdigest()
-    with open("data/%s.blob" % new_key, "wcb") as fd:
+    with open("data/{0!s}.blob".format(new_key), "wcb") as fd:
       fd.write(converted)
     return new_key
 

--- a/abilian/testing/__init__.py
+++ b/abilian/testing/__init__.py
@@ -396,5 +396,4 @@ class BaseTestCase(TestCase):
           message['lastLine'],
           message['extract'],
           message['message'])
-        self.fail((u'Got a validation error for %r:\n%s' %
-                   (url, detail)).encode('utf-8'))
+        self.fail((u'Got a validation error for {0!r}:\n{1!s}'.format(url, detail)).encode('utf-8'))

--- a/abilian/web/action.py
+++ b/abilian/web/action.py
@@ -357,7 +357,7 @@ class Action(object):
         assert isinstance(kwargs, dict)
         endpoint = self.Endpoint(endpoint, **kwargs)
       else:
-        raise ValueError('Invalid endpoint specifier: "%s"' % repr(endpoint))
+        raise ValueError('Invalid endpoint specifier: "{0!s}"'.format(repr(endpoint)))
 
     return endpoint
 

--- a/abilian/web/assets/filters.py
+++ b/abilian/web/assets/filters.py
@@ -235,7 +235,7 @@ class Less(ExternalTool):
     # Set working directory to the source file so that includes are found
     args = [self.less or 'lessc']
     if self.line_numbers:
-      args.append('--line-numbers=%s' % self.line_numbers)
+      args.append('--line-numbers={0!s}'.format(self.line_numbers))
 
     if self.paths:
       paths = [path if isabs(path) else self.ctx.resolver.resolve_source(path)

--- a/abilian/web/filters.py
+++ b/abilian/web/filters.py
@@ -70,23 +70,23 @@ def filesize(d):
     d = int(d)
 
   if d < 1000:
-    s = "%d&nbsp;B" % d
+    s = "{0:d}&nbsp;B".format(d)
 
   elif d < 1e4:
-    s = "%.1f&nbsp;kB" % (d / 1e3)
+    s = "{0:.1f}&nbsp;kB".format((d / 1e3))
   elif d < 1e6:
-    s = "%.0f&nbsp;kB" % (d / 1e3)
+    s = "{0:.0f}&nbsp;kB".format((d / 1e3))
 
   elif d < 1e7:
-    s = "%.1f&nbsp;MB" % (d / 1e6)
+    s = "{0:.1f}&nbsp;MB".format((d / 1e6))
   elif d < 1e9:
-    s = "%.0f&nbsp;MB" % (d / 1e6)
+    s = "{0:.0f}&nbsp;MB".format((d / 1e6))
 
   elif d < 1e10:
-    s = "%.1f&nbsp;GB" % (d / 1e9)
+    s = "{0:.1f}&nbsp;GB".format((d / 1e9))
 
   else:
-    s = "%.0f&nbsp;GB" % (d / 1e9)
+    s = "{0:.0f}&nbsp;GB".format((d / 1e9))
 
   return Markup(s)
 

--- a/abilian/web/forms/__init__.py
+++ b/abilian/web/forms/__init__.py
@@ -339,7 +339,7 @@ if not _PATCHED:
 
     return DefaultViewWidget().render_view(self, **kwargs)
 
-  patch_logger.info('Add method %s.Field.render_view' % Field.__module__)
+  patch_logger.info('Add method {0!s}.Field.render_view'.format(Field.__module__))
   Field.render_view = render_view
   del render_view
 
@@ -351,7 +351,7 @@ if not _PATCHED:
     return (self.flags.hidden
             or isinstance(self, HiddenField))
 
-  patch_logger.info('Add method %s.Field.is_hidden' % Field.__module__)
+  patch_logger.info('Add method {0!s}.Field.is_hidden'.format(Field.__module__))
   Field.is_hidden = property(is_hidden)
   del is_hidden
 

--- a/abilian/web/forms/widgets.py
+++ b/abilian/web/forms/widgets.py
@@ -64,7 +64,7 @@ def linkify_url(value):
 
   rjs = r'[\s]*(&#x.{1,7})?'.join(list('javascript:'))
   rvb = r'[\s]*(&#x.{1,7})?'.join(list('vbscript:'))
-  re_scripts = re.compile('(%s)|(%s)' % (rjs, rvb), re.IGNORECASE)
+  re_scripts = re.compile('({0!s})|({1!s})'.format(rjs, rvb), re.IGNORECASE)
 
   value = re_scripts.sub('', value)
 
@@ -86,7 +86,7 @@ def linkify_url(value):
   if value.count("/") == 1 and value.endswith("/"):
     value = value[0:-1]
 
-  return '<a href="%s">%s</a>&nbsp;<i class="fa fa-external-link"></i>' % (url, value)
+  return '<a href="{0!s}">{1!s}</a>&nbsp;<i class="fa fa-external-link"></i>'.format(url, value)
 
 
 def text2html(text):
@@ -98,7 +98,7 @@ def text2html(text):
 
   lines = text.split("\n")
   lines = [ line for line in lines if line ]
-  paragraphs = ['<p>%s</p>' % line for line in lines]
+  paragraphs = ['<p>{0!s}</p>'.format(line) for line in lines]
   return Markup(bleach.clean("\n".join(paragraphs), tags=['p']))
 
 
@@ -221,11 +221,9 @@ class BaseTableView(object):
         cell = format(value)
       elif column_name == make_link_on or column_name == 'name' or \
          col.get('linkable'):
-        cell = Markup('<a href="%s">%s</a>'
-                      % (build_url(entity), cgi.escape(unicode(value))))
+        cell = Markup('<a href="{0!s}">{1!s}</a>'.format(build_url(entity), cgi.escape(unicode(value))))
       elif isinstance(value, Entity):
-        cell = Markup('<a href="%s">%s</a>'
-                      % (build_url(value), cgi.escape(value.name)))
+        cell = Markup('<a href="{0!s}">{1!s}</a>'.format(build_url(value), cgi.escape(value.name)))
       elif isinstance(value, string_types) \
           and (value.startswith("http://") or value.startswith("www.")):
         cell = Markup(linkify_url(value))
@@ -382,17 +380,14 @@ class AjaxMainTableView(object):
       if has_custom_display:
         cell = value
       elif column_name == 'name':
-        cell = Markup('<a href="%s">%s</a>'
-                      % (url_for(entity), cgi.escape(value)))
+        cell = Markup('<a href="{0!s}">{1!s}</a>'.format(url_for(entity), cgi.escape(value)))
       elif isinstance(value, Entity):
-        cell = Markup('<a href="%s">%s</a>'
-                      % (url_for(value), cgi.escape(value.name)))
+        cell = Markup('<a href="{0!s}">{1!s}</a>'.format(url_for(value), cgi.escape(value.name)))
       elif (isinstance(value, string_types)
             and (value.startswith("http://") or value.startswith("www."))):
         cell = Markup(linkify_url(value))
       elif col.get('linkable'):
-        cell = Markup('<a href="%s">%s</a>'
-                      % (url_for(entity), cgi.escape(unicode(value))))
+        cell = Markup('<a href="{0!s}">{1!s}</a>'.format(url_for(entity), cgi.escape(unicode(value))))
       else:
         cell = unicode(value)
 
@@ -851,7 +846,7 @@ class Chosen(Select):
 
   def __call__(self, field, **kwargs):
     kwargs.setdefault('id', field.id)
-    html = [u'<select %s class="chzn-select">' % html_params(name=field.name, **kwargs)]
+    html = [u'<select {0!s} class="chzn-select">'.format(html_params(name=field.name, **kwargs))]
     for val, label, selected in field.iter_choices():
       html.append(self.render_option(val, label, selected))
     html.append(u'</select>')
@@ -862,7 +857,7 @@ class Chosen(Select):
     options = dict(kwargs, value=value)
     if selected:
       options['selected'] = True
-    return HTMLString(u'<option %s>%s</option>' % (html_params(**options), cgi.escape(unicode(label))))
+    return HTMLString(u'<option {0!s}>{1!s}</option>'.format(html_params(**options), cgi.escape(unicode(label))))
 
 
 class TagInput(Input):
@@ -876,7 +871,7 @@ class TagInput(Input):
     if 'value' not in kwargs:
       kwargs['value'] = field._value()
 
-    return HTMLString(u'<input %s>' % self.html_params(name=field.name, **kwargs))
+    return HTMLString(u'<input {0!s}>'.format(self.html_params(name=field.name, **kwargs)))
 
 
 class DateInput(Input):
@@ -1265,11 +1260,11 @@ class ListWidget(wtforms.widgets.ListWidget):
       return super(ListWidget, self).__call__(field, **kwargs)
 
     kwargs.setdefault('id', field.id)
-    html = [u'<%s %s>' % (self.html_tag, wtforms.widgets.html_params(**kwargs))]
+    html = [u'<{0!s} {1!s}>'.format(self.html_tag, wtforms.widgets.html_params(**kwargs))]
     for subfield in field:
       html.append(u'<li>{}</li>'.format(subfield()))
 
-    html.append(u'</%s>' % self.html_tag)
+    html.append(u'</{0!s}>'.format(self.html_tag))
     return wtforms.widgets.HTMLString(''.join(html))
 
   def render_view(self, field, **kwargs):

--- a/abilian/web/frontend.py
+++ b/abilian/web/frontend.py
@@ -554,10 +554,10 @@ class Module(object):
 
     # If url is not provided, generate it from endpoint name
     if self.url is None:
-      self.url = '%s/%s' % (self.crud_app.url, self.endpoint)
+      self.url = '{0!s}/{1!s}'.format(self.crud_app.url, self.endpoint)
     else:
       if not self.url.startswith('/'):
-        self.url = '%s/%s' % (self.crud_app.url, self.url)
+        self.url = '{0!s}/{1!s}'.format(self.crud_app.url, self.url)
 
     # Create blueprint and register rules
     self.blueprint = Blueprint(self.endpoint, __name__,

--- a/abilian/web/tests/test_actions.py
+++ b/abilian/web/tests/test_actions.py
@@ -18,7 +18,7 @@ CONDITIONAL = Action('cat_1', 'conditional', 'Conditional Action',
                      icon=Glyphicon('hand-right'), button='warning')
 
 OTHER_CAT = Action('cat_2:sub', 'other', 'Other Action',
-                   url=lambda ctx: 'http://count?%d' % len(ctx),
+                   url=lambda ctx: 'http://count?{0:d}'.format(len(ctx)),
                    icon=StaticIcon('icons/other.png', size=14),
                    css='custom-class')
 

--- a/abilian/web/views/base.py
+++ b/abilian/web/views/base.py
@@ -28,7 +28,7 @@ class View(BaseView):
     # retry with GET
     if meth is None and request.method == 'HEAD':
       meth = getattr(self, 'get', None)
-      assert meth is not None, 'Unimplemented method %r' % request.method
+      assert meth is not None, 'Unimplemented method {0!r}'.format(request.method)
 
     g.view = actions.context['view'] = self
     try:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:abilian:abilian-core?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:abilian:abilian-core?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)