### PR TITLE
Enable debug toolbar on testing, please

### DIFF
--- a/abilian/app.py
+++ b/abilian/app.py
@@ -466,7 +466,7 @@ class Application(Flask, ServiceManager, PluginManager):
             logging.config.dictConfig(logging_cfg)
 
     def init_debug_toolbar(self):
-        if (not self.testing and self.config.get('DEBUG_TB_ENABLED') and
+        if (self.testing and self.config.get('DEBUG_TB_ENABLED') and
                 'debugtoolbar' not in self.blueprints):
             try:
                 from flask_debugtoolbar import DebugToolbarExtension


### PR DESCRIPTION
I'm surprised it was like that. But it prevented me from seeing the toolbar even with `TETSING = True` in my config.