### PR TITLE
fix error on logging

### DIFF
--- a/abilian/web/views/object.py
+++ b/abilian/web/views/object.py
@@ -653,9 +653,9 @@ class JSONWhooshSearch(JSONBaseSearch):
             # 'nom' doesn't always exist but for Contacts, sorting on
             # the last name ('nom') feels more natural than 'name',
             # which starts with the first name ('prenom').
+            itemkey = None
             res = results[0]
             fields = res.fields()
-            itemkey = None
             if 'nom' in fields:
                 itemkey = 'nom'
             elif 'name' in fields:
@@ -664,9 +664,10 @@ class JSONWhooshSearch(JSONBaseSearch):
                 results = sorted(
                     results, key=lambda it: it.fields().get(itemkey))
         except Exception:
-            logger.warning(
-                "we could not sort whoosh results on fields' key {}.".format(
-                    itemkey))
+            if itemkey is not None:
+                logger.warning(
+                    "we could not sort whoosh results on fields' key {}.".format(
+                        itemkey))
 
         return results
 


### PR DESCRIPTION
> 'itemkey' referenced before assignment.

This log is interesting only when itemkey is either 'name' or
'nom'. Nothing to log otherwise.

fixes https://sentry.io/abilian/extranet-mpr-demo/issues/255028004/