### PR TITLE
Module json2: allow to call another search method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ vagrant-tests:
 #
 # Various Checkers
 #
+flake8:
+	flake8 $(SRC)
+
 lint: lint-ci lint-travis
 
 lint-ci: lint-py lint-js lint-less lint-rst lint-doc lint-mypy

--- a/abilian/web/frontend.py
+++ b/abilian/web/frontend.py
@@ -764,6 +764,7 @@ class Module(object):
             .limit(self.JSON2_SEARCH_LENGTH)
         results = query.all()
         results = [{'id': r[0], 'text': r[1]} for r in results]
+        return results
 
     @expose("/json2")
     def list_json2(self):

--- a/abilian/web/frontend.py
+++ b/abilian/web/frontend.py
@@ -748,13 +748,6 @@ class Module(object):
     def list_json2(self):
         """Other JSON endpoint, this time used for filling select boxes dynamically.
 
-        Used for:
-        - the Visite Compte search
-        - Bilan
-        - Projet partenaire
-        - Adhesion rapprochement
-        and maybe others.
-
         You can write your own search method in list_json2_query_all,
         that returns a list of results (not json).
 

--- a/abilian/web/frontend.py
+++ b/abilian/web/frontend.py
@@ -407,6 +407,7 @@ class Module(object):
     create_cls = EntityCreate
     delete_cls = EntityDelete
     json_search_cls = JSONWhooshSearch
+    JSON2_SEARCH_LENGTH = 50
 
     # form_class. Used when view_cls/edit_cls are not provided
     edit_form_class = None
@@ -760,7 +761,7 @@ class Module(object):
             .filter(cls.name.ilike("%" + q + "%")) \
             .distinct() \
             .order_by(cls.name) \
-            .limit(50)
+            .limit(self.JSON2_SEARCH_LENGTH)
         results = query.all()
         results = [{'id': r[0], 'text': r[1]} for r in results]
 

--- a/abilian/web/frontend.py
+++ b/abilian/web/frontend.py
@@ -745,10 +745,14 @@ class Module(object):
         return render_template("default/list_view.html", **ctx)
 
     def list_json2_query_all(self, q):
-        """
-        Implements the search query for the list_json2 endpoint.
+        """Implements the search query for the list_json2 endpoint.
 
-        - Return: a list of results (not json).
+        May be re-defined by a Module subclass in order to customize
+        the search results.
+
+        - Return: a list of results (not json) with an 'id' and a
+          'text' (that will be displayed in the select2).
+
         """
         cls = self.managed_class
         query = db.session.query(cls.id, cls.name, cls.adresse_id)
@@ -758,7 +762,7 @@ class Module(object):
             .order_by(cls.name) \
             .limit(50)
         results = query.all()
-        results = {'results': [{'id': r[0], 'text': r[1]} for r in results]}
+        results = [{'id': r[0], 'text': r[1]} for r in results]
 
     @expose("/json2")
     def list_json2(self):
@@ -775,6 +779,7 @@ class Module(object):
             raise BadRequest()
 
         results = self.list_json2_query_all(q)
+        results = {'results': results}
         return jsonify(results)
 
     #


### PR DESCRIPTION
this is an api endpoint (Module.json2) that searches with a regular
database query (not Whoosh). Some modules may want to have their own
search method (so as to add bonus information into the text results for
example), so we call it if any or we rely on the basic
search (name.ilike).